### PR TITLE
Improve Error Message

### DIFF
--- a/constant.go
+++ b/constant.go
@@ -21,6 +21,9 @@ const (
 
 	// ErrFieldExceedsMaximumValue represents an error message for a field that exceeds the maximum allowed value.
 	ErrFieldExceedsMaximumValue = "The '%s' field must not exceed %d"
+
+	// ErrFieldsMustContainNumbersOnly represents an error message for multiple fields that must contain only numbers.
+	ErrFieldsMustContainNumbersOnly = "The '%s' fields must contain only numbers"
 )
 
 const (

--- a/restrict_number.go
+++ b/restrict_number.go
@@ -63,7 +63,7 @@ func (r RestrictNumberOnly) restrictJSON(c *fiber.Ctx) error {
 	}
 
 	if len(invalidFields) > 0 {
-		return NewError(fiber.StatusBadRequest, fmt.Sprintf("The '%s' fields must contain only numbers", strings.Join(invalidFields, "', '")))
+		return NewError(fiber.StatusBadRequest, fmt.Sprintf(ErrFieldsMustContainNumbersOnly, strings.Join(invalidFields, "', '")))
 	}
 
 	return nil
@@ -101,7 +101,7 @@ func (r RestrictNumberOnly) restrictXML(c *fiber.Ctx) error {
 	}
 
 	if len(invalidFields) > 0 {
-		return NewError(fiber.StatusBadRequest, fmt.Sprintf("The '%s' fields must contain only numbers", strings.Join(invalidFields, "', '")))
+		return NewError(fiber.StatusBadRequest, fmt.Sprintf(ErrFieldsMustContainNumbersOnly, strings.Join(invalidFields, "', '")))
 	}
 
 	return nil
@@ -125,7 +125,7 @@ func (r RestrictNumberOnly) restrictOther(c *fiber.Ctx) error {
 	}
 
 	if len(invalidFields) > 0 {
-		return NewError(fiber.StatusBadRequest, fmt.Sprintf("The '%s' fields must contain only numbers", strings.Join(invalidFields, "', '")))
+		return NewError(fiber.StatusBadRequest, fmt.Sprintf(ErrFieldsMustContainNumbersOnly, strings.Join(invalidFields, "', '")))
 	}
 
 	return nil


### PR DESCRIPTION
- [+] feat(constant.go): add ErrFieldsMustContainNumbersOnly constant for error message
- [+] refactor(restrict_number.go): use ErrFieldsMustContainNumbersOnly constant in restrictJSON, restrictXML, and restrictOther methods